### PR TITLE
Typo in 'hypopnea'

### DIFF
--- a/AHI3code.py
+++ b/AHI3code.py
@@ -62,7 +62,7 @@ AHI_PATTERNS = [
     re.compile(r'\bAHI\s+was\s+(?P<val>\d+(?:\.\d+)?)', re.IGNORECASE),
     re.compile(r'\bAHI\s+is\s+(?P<val>\d+(?:\.\d+)?)', re.IGNORECASE),
     re.compile(r'\bAHI\s*\(apnea[-\s]?hypopnea index\)\s*,?\s*events per hour of sleep\s*:\s*(?P<val>\d+(?:\.\d+)?)', re.IGNORECASE),
-    re.compile(r'Apnea-?Hypopnnea\s+Index\s*\(AHI\)\s*:\s*(?P<val>\d+(?:\.\d+)?)\s*per\s*hour', re.IGNORECASE),
+    re.compile(r'Apnea-?Hypopnea\s+Index\s*\(AHI\)\s*:\s*(?P<val>\d+(?:\.\d+)?)\s*per\s*hour', re.IGNORECASE),
 ]
 
 # ESS patterns (unchanged)

--- a/code3t.py
+++ b/code3t.py
@@ -57,7 +57,7 @@ AHI_PATTERNS = [
     re.compile(r'\bAHI\s+was\s+(?P<val>\d+(?:\.\d+)?)', re.IGNORECASE),
     re.compile(r'\bAHI\s+is\s+(?P<val>\d+(?:\.\d+)?)', re.IGNORECASE),
     re.compile(r'\bAHI\s*\(apnea[-\s]?hypopnea index\)\s*,?\s*events per hour of sleep\s*:\s*(?P<val>\d+(?:\.\d+)?)', re.IGNORECASE),
-    re.compile(r'Apnea-?Hypopnnea\s+Index\s*\(AHI\)\s*:\s*(?P<val>\d+(?:\.\d+)?)\s*per\s*hour', re.IGNORECASE)
+    re.compile(r'Apnea-?Hypopnea\s+Index\s*\(AHI\)\s*:\s*(?P<val>\d+(?:\.\d+)?)\s*per\s*hour', re.IGNORECASE)
 ]
 
 # ESS patterns (unchanged)


### PR DESCRIPTION
In the last regex in each version, there's a doubled 'n' which is presumably a typo.
